### PR TITLE
Add Tagged Enemies Option to Advanced Options

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -65,6 +65,7 @@ OvaleOptions.defaultDB = {
 			predictif = false,
 			secondIconScale = 1,
 			-- Advanced
+			taggedEnemies = false,
 			auraLag = 400,
 		},
 	},
@@ -358,9 +359,14 @@ OvaleOptions.options = {
 					name = "Advanced",
 					args =
 					{
+						taggedEnemies = {
+							order = 10,
+							type = "toggle",
+							name = L["Use Tagged Enemies"],
+						},
 						auraLag =
 						{
-							order = 10,
+							order = 20,
 							type = "range",
 							name = L["Aura lag"],
 							desc = L["Lag (in milliseconds) between when an spell is cast and when the affected aura is applied or removed"],


### PR DESCRIPTION
This change adds and option to the Advanced Options to select whether the Enemies() script command returns tagged enemies or all enemies by default.
