### PR TITLE
Rewrite of Enemies.lua

### DIFF
--- a/Enemies.lua
+++ b/Enemies.lua
@@ -2,275 +2,503 @@
     Copyright (C) 2012 Sidoine De Wispelaere.
     Copyright (C) 2012, 2013, 2014 Johnny C. Lam.
     See the file LICENSE.txt for copying permission.
+    
+    Module rewritten by Adrian Hamilton (LunaEclipse)
 --]]--------------------------------------------------------------------
 
 -- Gather information about ennemies
 
-local OVALE, Ovale = ...
-local OvaleEnemies = Ovale:NewModule("OvaleEnemies", "AceEvent-3.0", "AceTimer-3.0")
-Ovale.OvaleEnemies = OvaleEnemies
+local OVALE, Ovale = ...;
+local OvaleEnemies = Ovale:NewModule("OvaleEnemies", "AceEvent-3.0", "AceTimer-3.0");
+Ovale.OvaleEnemies = OvaleEnemies;
 
 --<private-static-properties>
-local L = Ovale.L
-local OvaleDebug = Ovale.OvaleDebug
-local OvaleProfiler = Ovale.OvaleProfiler
+local L = Ovale.L;
+local OvaleDebug = Ovale.OvaleDebug;
+local OvaleProfiler = Ovale.OvaleProfiler;
 
 -- Forward declarations for module dependencies.
-local OvaleState = nil
-
-local bit_band = bit.band
-local ipairs = ipairs
-local pairs = pairs
-local strfind = string.find
-local tostring = tostring
-local wipe = wipe
-local API_GetTime = GetTime
-local COMBATLOG_OBJECT_AFFILIATION_OUTSIDER = COMBATLOG_OBJECT_AFFILIATION_OUTSIDER
-local COMBATLOG_OBJECT_REACTION_HOSTILE = COMBATLOG_OBJECT_REACTION_HOSTILE
+local OvaleState = nil;
 
 -- Register for debugging messages.
-OvaleDebug:RegisterDebugging(OvaleEnemies)
+OvaleDebug:RegisterDebugging(OvaleEnemies);
 -- Register for profiling.
-OvaleProfiler:RegisterProfiling(OvaleEnemies)
-
--- List of CLEU event suffixes that can correspond to the player damaging or try to damage (tag) an enemy.
-local CLEU_TAG_SUFFIXES = {
-	"_CAST_START",
-	"_DAMAGE",
-	"_MISSED",
-	"_DRAIN",
-	"_LEECH",
-	"_INTERRUPT",
-	"_DISPEL",
-	"_DISPEL_FAILED",
-	"_STOLEN",
-	"_AURA_APPLIED",
-	"_AURA_APPLIED_DOSE",
-	"_AURA_REFRESH",
-}
+OvaleProfiler:RegisterProfiling(OvaleEnemies);
 
 -- Player's GUID.
-local self_playerGUID = nil
+local playerGUID = nil;
 
--- enemyName[guid] = name
-local self_enemyName = {}
--- enemyLastSeen[guid] = timestamp
-local self_enemyLastSeen = {}
--- taggedEnemyLastSeen[guid] = timestamp
--- GUIDs used as keys for this table are a subset of the GUIDs used for enemyLastSeen.
-local self_taggedEnemyLastSeen = {}
+-- targets[guid] = timestamp;
+local targets = {};
+-- myTargets[guid] = timestamp;
+-- GUIDs used as keys for this table are a subset of the GUIDs used for targets.
+local myTargets = {};
+-- minions[guid] = timestamp;
+-- GUIDs of units summoned by the player.
+local minions = {};
 
 -- Timer for reaper function to remove inactive enemies.
-local self_reaperTimer = nil
-local REAP_INTERVAL = 3
+local reaperTimer = nil;
+local REAP_INTERVAL = 3;
 --</private-static-properties>
 
 --<public-static-properties>
 -- Total number of active enemies.
-OvaleEnemies.activeEnemies = 0
+OvaleEnemies.activeEnemies = 0;
 -- Total number of tagged enemies.
-OvaleEnemies.taggedEnemies = 0
+OvaleEnemies.taggedEnemies = 0;
+-- Total number of player minions.
+OvaleEnemies.playerMinions = 0;
 --</public-static-properties>
 
 --<private-static-methods>
-local function IsTagEvent(cleuEvent)
-	for _, suffix in ipairs(CLEU_TAG_SUFFIXES) do
-		if strfind(cleuEvent, suffix .. "$") then
-			return true
-		end
+local function abilityUsedEvent(combatEvent)
+	local returnValue = false;
+	
+	if combatEvent == "SPELL_DAMAGE"
+	   or combatEvent == "SPELL_MISSED" then
+	   	returnValue = true;
 	end
-	return false
+	
+	return returnValue;	   	
+end
+
+local function autoAttackEvent(combatEvent)
+	local returnValue = false;
+	
+	if combatEvent == "RANGE_DAMAGE"
+	   or combatEvent == "RANGE_MISSED"
+	   or combatEvent == "SWING_DAMAGE" 
+	   or combatEvent == "SWING_MISSED" then
+	   	returnValue = true;
+	end
+	
+	return returnValue;	   	
+end
+
+local function damageOverTimeEvent(combatEvent)
+	local returnValue = false;
+	
+	if combatEvent == "SPELL_AURA_APPLIED"
+	   or combatEvent == "SPELL_AURA_REFRESH"
+	   or combatEvent == "SPELL_PERIODIC_DAMAGE" 
+	   or combatEvent == "SPELL_PERIODIC_MISSED" then
+	   	returnValue = true;
+	end
+	
+	return returnValue;	   	
+end
+
+local function deathEvent(combatEvent)
+	local returnValue = false;
+	
+	if combatEvent == "UNIT_DIED" 
+	    or combatEvent == "UNIT_DESTROYED" then
+	   	returnValue = true;
+	end
+	
+	return returnValue;	   	
+end
+
+local function playerSummonEvent(combatEvent, sourceIsPlayer)
+	local returnValue = false;
+	
+	if combatEvent == "SPELL_SUMMON" 
+	   and sourceIsPlayer then
+	   	returnValue = true;
+	end
+	
+	return returnValue;	   	
+end
+
+local function isValidEvent(combatEvent)
+	local returnValue = false;
+
+	if abilityUsedEvent(combatEvent) then 
+		returnValue = true;
+	end
+
+	if damageOverTimeEvent(combatEvent) then 
+		returnValue = true;
+	end
+
+--[[ 
+	The following lines can be used to detect enemies on auto-attacks as well
+	but doing so greatly reduces FPS, testing showed up to 15% reduction.
+	
+	Use with extreme caution.
+
+	if autoAttackEvent(combatEvent) then 
+		returnValue = true;
+	end
+]]--
+
+	return returnValue;
+end
+
+local function bothUnitsExist(sourceGUID, destGUID)
+	local returnValue = false;
+	
+	if (sourceGUID and sourceGUID ~= "")
+	    and (destGUID and destGUID ~= "") then
+		returnValue = true;
+	end
+	
+	return returnValue;
+end
+
+local function isEnemy(targetFlags)
+	local returnValue = false;
+	
+	if bit.band(targetFlags, COMBATLOG_OBJECT_REACTION_FRIENDLY) == 0 then
+		returnValue = true;
+	end
+	
+	return returnValue;
+end
+
+local function isGroupMember(targetFlags)
+	local returnValue = false;
+	
+	if (bit.band(targetFlags, COMBATLOG_OBJECT_AFFILIATION_MINE) ~= 0)
+	    or (bit.band(targetFlags, COMBATLOG_OBJECT_AFFILIATION_PARTY) ~= 0) 
+	    or (bit.band(targetFlags, COMBATLOG_OBJECT_AFFILIATION_RAID) ~= 0) then
+		returnValue = true;
+	end
+	
+	return returnValue;
+end
+
+local function isPlayer(targetFlags)
+	local returnValue = false;
+	
+	if bit.band(targetFlags, COMBATLOG_OBJECT_AFFILIATION_MINE) ~= 0 then
+		returnValue = true;
+	end
+	
+	return returnValue;
+end
+
+local function validObject(targetFlags)
+	local returnValue = false;
+	
+	if (bit.band(targetFlags, COMBATLOG_OBJECT_TYPE_PET) ~= 0)
+	    or (bit.band(targetFlags, COMBATLOG_OBJECT_TYPE_NPC) ~= 0) 
+	    or (bit.band(targetFlags, COMBATLOG_OBJECT_TYPE_PLAYER) ~= 0) then
+		returnValue = true;
+	end
+	
+	return returnValue;
+end
+
+local function wipeData()
+	targets = {};
+	OvaleEnemies.activeEnemies = 0;
+
+	myTargets = {};
+	OvaleEnemies.taggedEnemies = 0;
+
+	minions = {};
+	OvaleEnemies.playerMinions = 0;
+end
+
+local function getTargetInfo(targetFlags)
+	local targetIsPlayer = isPlayer(targetFlags);
+	local targetIsEnemy = isEnemy(targetFlags);
+	local targetIsValid = validObject(targetFlags);
+	local targetIsGroupMember = isGroupMember(targetFlags);
+
+	return targetIsPlayer, targetIsGroupMember, targetIsEnemy, targetIsValid;
 end
 --</private-static-methods>
 
 --<public-static-methods>
 function OvaleEnemies:OnInitialize()
 	-- Resolve module dependencies.
-	OvaleState = Ovale.OvaleState
+	OvaleState = Ovale.OvaleState;
 end
 
 function OvaleEnemies:OnEnable()
-	self_playerGUID = Ovale.playerGUID
-	if not self_reaperTimer then
-		self_reaperTimer = self:ScheduleRepeatingTimer("RemoveInactiveEnemies", REAP_INTERVAL)
+	playerGUID = Ovale.playerGUID;
+
+	if not reaperTimer then
+		reaperTimer = self:ScheduleRepeatingTimer("RemoveInactiveEnemies", REAP_INTERVAL);
 	end
-	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
-	self:RegisterEvent("PLAYER_REGEN_DISABLED")
-	OvaleState:RegisterState(self, self.statePrototype)
+	
+	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
+	self:RegisterEvent("PLAYER_REGEN_DISABLED");
+	
+	OvaleState:RegisterState(self, self.statePrototype);
 end
 
 function OvaleEnemies:OnDisable()
-	OvaleState:UnregisterState(self)
-	if not self_reaperTimer then
-		self:CancelTimer(self_reaperTimer)
-		self_reaperTimer = nil
+	OvaleState:UnregisterState(self);
+	
+	if not reaperTimer then
+		self:CancelTimer(reaperTimer);
+		reaperTimer = nil;
 	end
-	self:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
-	self:UnregisterEvent("PLAYER_REGEN_DISABLED")
+	
+	self:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
+	self:UnregisterEvent("PLAYER_REGEN_DISABLED");
 end
 
-function OvaleEnemies:COMBAT_LOG_EVENT_UNFILTERED(event, timestamp, cleuEvent, hideCaster, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, ...)
-	if cleuEvent == "UNIT_DIED" then
-		local now = API_GetTime()
-		self:RemoveEnemy(destGUID, now, true)
-	elseif sourceFlags and bit_band(sourceFlags, COMBATLOG_OBJECT_REACTION_HOSTILE) > 0
-			and bit_band(sourceFlags, COMBATLOG_OBJECT_AFFILIATION_OUTSIDER) > 0
-			and destFlags and bit_band(destFlags, COMBATLOG_OBJECT_AFFILIATION_OUTSIDER) == 0 then
-		local now = API_GetTime()
-		self:AddEnemy(sourceGUID, sourceName, now)
-	elseif destGUID and bit_band(destFlags, COMBATLOG_OBJECT_REACTION_HOSTILE) > 0
-			and bit_band(destFlags, COMBATLOG_OBJECT_AFFILIATION_OUTSIDER) > 0
-			and sourceFlags and bit_band(sourceFlags, COMBATLOG_OBJECT_AFFILIATION_OUTSIDER) == 0 then
-		local now = API_GetTime()
-		local isTagged = (sourceGUID == self_playerGUID and IsTagEvent(cleuEvent))
-		self:AddEnemy(destGUID, destName, now, isTagged)
+function OvaleEnemies:COMBAT_LOG_EVENT_UNFILTERED(event, ...)
+	local _, combatEvent, _, sourceGUID, _, sourceFlags, _, destGUID, _, destFlags = ...;
+	local currentTime = GetTime();
+
+	local sourceIsPlayer, sourceIsGroupMember, sourceIsEnemy, sourceIsValid = getTargetInfo(sourceFlags);
+	local destIsPlayer, destIsGroupMember, destIsEnemy, destIsValid = getTargetInfo(destFlags);
+	
+	if deathEvent(combatEvent) then
+		self:RemoveEnemy(destGUID, true);
+		self:RemoveMinion(destGUID, true);
+
+		return;
+	end
+
+	if bothUnitsExist(sourceGUID, destGUID) then
+		if sourceIsGroupMember or destIsGroupMember then
+			if playerSummonEvent(combatEvent, sourceIsPlayer) then
+				self:AddMinion(destGUID, currentTime);
+
+				return;
+			end
+
+			if isValidEvent(combatEvent) then
+				if sourceIsGroupMember and destIsValid and destIsEnemy then
+					self:AddEnemy(destGUID, currentTime, sourceIsPlayer);
+
+					return;
+				end
+
+				if destIsGroupMember and sourceIsValid and sourceIsEnemy then
+					self:AddEnemy(sourceGUID, currentTime);
+
+					return;
+				end
+			end
+		end
 	end
 end
 
 function OvaleEnemies:PLAYER_REGEN_DISABLED()
 	-- Reset enemy tracking when combat starts.
-	wipe(self_enemyName)
-	wipe(self_enemyLastSeen)
-	wipe(self_taggedEnemyLastSeen)
-	self.activeEnemies = 0
-	self.taggedEnemies = 0
+	wipeData();
 end
 
 -- Remove enemies that have been inactive for at least REAP_INTERVAL seconds.
 -- These enemies are not in combat with your group, out of range, or
 -- incapacitated and shouldn't count toward the number of active enemies.
 function OvaleEnemies:RemoveInactiveEnemies()
-	self:StartProfiling("OvaleEnemies_RemoveInactiveEnemies")
-	local now = API_GetTime()
-	for guid, timestamp in pairs(self_enemyLastSeen) do
-		if now - timestamp > REAP_INTERVAL then
-			self:RemoveEnemy(guid, now)
+	self:StartProfiling("OvaleEnemies_RemoveInactiveEnemies");
+	
+	local currentTime = GetTime();
+
+	for GUID, timeStamp in pairs(targets) do
+		if currentTime - timeStamp > REAP_INTERVAL then
+			self:RemoveEnemy(GUID);
 		end
 	end
-	self:StopProfiling("OvaleEnemies_RemoveInactiveEnemies")
+
+	for GUID, timeStamp in pairs(minions) do
+		if currentTime - timeStamp > REAP_INTERVAL then
+			self:RemoveMinion(GUID);
+		end
+	end
+	
+	self:StopProfiling("OvaleEnemies_RemoveInactiveEnemies");
 end
 
-function OvaleEnemies:AddEnemy(guid, name, timestamp, isTagged)
-	self:StartProfiling("OvaleEnemies_AddEnemy")
-	if guid then
-		self_enemyName[guid] = name
-		local tagged = self_taggedEnemyLastSeen[guid]
-		if isTagged then
-			local tagged = self_taggedEnemyLastSeen[guid]
-			self_taggedEnemyLastSeen[guid] = timestamp
-			if not tagged then
-				self.taggedEnemies = self.taggedEnemies + 1
-			end
-		end
-		local seen = self_enemyLastSeen[guid]
-		self_enemyLastSeen[guid] = timestamp
-		if not seen then
-			self.activeEnemies = self.activeEnemies + 1
-		end
-		if isTagged and not tagged then
-			self:DebugTimestamp("New tagged enemy seen (%d total, %d tagged): %s (%s)", self.activeEnemies, self.taggedEnemies, guid, name)
-			Ovale.refreshNeeded[self_playerGUID] = true
-		elseif not seen then
-			self:DebugTimestamp("New enemy seen (%d total): %s (%s)", self.activeEnemies, guid, name)
-			Ovale.refreshNeeded[self_playerGUID] = true
-		end
+
+function OvaleEnemies:AddMinion(GUID, timeStamp)
+	self:StartProfiling("OvaleEnemies_AddMinion");
+
+	if not minions[GUID] then
+		OvaleEnemies.playerMinions = OvaleEnemies.playerMinions + 1;
+		minions[GUID] = timeStamp;
+
+		self:DebugTimestamp("New player minion seen (%d total): %s", self.playerMinions, GUID);
+	else
+		minions[GUID] = timeStamp;
 	end
-	self:StopProfiling("OvaleEnemies_AddEnemy")
+	
+	self:StopProfiling("OvaleEnemies_AddMinion");
 end
 
-function OvaleEnemies:RemoveEnemy(guid, timestamp, isDead)
-	self:StartProfiling("OvaleEnemies_RemoveEnemy")
-	if guid then
-		local name = self_enemyName[guid]
-		local seen = self_enemyLastSeen[guid]
-		local tagged = self_taggedEnemyLastSeen[guid]
-		if tagged then
-			self_taggedEnemyLastSeen[guid] = nil
-			if self.taggedEnemies > 0 then
-				self.taggedEnemies = self.taggedEnemies - 1
-			end
-		end
-		if seen then
-			self_enemyLastSeen[guid] = nil
-			if self.activeEnemies > 0 then
-				self.activeEnemies = self.activeEnemies - 1
-			end
-		end
-		if tagged then
-			if isDead then
-				self:DebugTimestamp("Tagged enemy died (%d total, %d tagged): %s (%s)", self.activeEnemies, self.taggedEnemies, guid, name)
-			else
-				self:DebugTimestamp("Tagged enemy removed( %d total, %d tagged): %s (%s), last seen at %f", self.activeEnemies, self.taggedEnemies, guid, name, tagged)
-			end
-		elseif seen then
-			if isDead then
-				self:DebugTimestamp("Enemy died (%d total): %s (%s)", self.activeEnemies, guid, name)
-			else
-				self:DebugTimestamp("Enemy removed (%d total): %s (%s), last seen at %f", self.activeEnemies, guid, name, seen)
-			end
-		end
-		if tagged or seen then
-			Ovale.refreshNeeded[self_playerGUID] = true
-			self:SendMessage("Ovale_InactiveUnit", guid, isDead)
+function OvaleEnemies:RemoveMinion(GUID, deathEvent)
+	self:StartProfiling("OvaleEnemies_RemoveMinion");
+
+	local unitDied;
+
+	if not deathEvent then
+		unitDied = false;
+	else
+		unitDied = true;
+	end
+
+	if minions[GUID] ~= nil then
+		local lastSeen = minions[GUID];
+
+		OvaleEnemies.playerMinions = max(0, OvaleEnemies.playerMinions - 1);
+		minions[GUID] = nil;
+
+		if unitDied then
+			self:DebugTimestamp("Player minion died (%d total): %s", self.playerMinions, GUID);
+		else
+			self:DebugTimestamp("Player minion removed (%d total): %s, last seen at %f", self.playerMinions, GUID, lastSeen);
 		end
 	end
-	self:StopProfiling("OvaleEnemies_RemoveEnemy")
+	
+	self:StopProfiling("OvaleEnemies_RemoveMinion");
+end
+
+function OvaleEnemies:AddEnemy(GUID, timeStamp, playerTarget)
+	self:StartProfiling("OvaleEnemies_AddEnemy");
+
+	if not targets[GUID] then
+		OvaleEnemies.activeEnemies = OvaleEnemies.activeEnemies + 1;
+		targets[GUID] = timeStamp;
+
+		self:DebugTimestamp("New enemy seen (%d total): %s", self.activeEnemies, GUID);
+		Ovale.refreshNeeded[playerGUID] = true;
+	else
+		targets[GUID] = timeStamp;
+	end
+
+	if playerTarget then
+		if not myTargets[GUID] then
+			OvaleEnemies.taggedEnemies = OvaleEnemies.taggedEnemies + 1;
+			myTargets[GUID] = timeStamp;
+
+			self:DebugTimestamp("New tagged enemy seen (%d total, %d tagged): %s", self.activeEnemies, self.taggedEnemies, GUID);
+			Ovale.refreshNeeded[playerGUID] = true;
+		else
+			myTargets[GUID] = timeStamp;
+		end
+	end 
+	
+	self:StopProfiling("OvaleEnemies_AddEnemy");
+end
+
+function OvaleEnemies:RemoveEnemy(GUID, deathEvent)
+	self:StartProfiling("OvaleEnemies_RemoveEnemy");
+
+	local refreshNeeded = false;
+	local unitDied;
+
+	if not deathEvent then
+		unitDied = false;
+	else
+		unitDied = true;
+	end
+
+	if targets[GUID] ~= nil then
+		local lastSeen = targets[GUID];
+
+		OvaleEnemies.activeEnemies = max(0, OvaleEnemies.activeEnemies - 1);
+		targets[GUID] = nil;
+
+		if unitDied then
+			self:DebugTimestamp("Enemy died (%d total): %s", self.activeEnemies, GUID);
+		else
+			self:DebugTimestamp("Enemy removed (%d total): %s, last seen at %f", self.activeEnemies, GUID, lastSeen);
+		end
+		
+		refreshNeeded = true;
+	end
+
+	if myTargets[GUID] ~= nil then
+		local taggedLastSeen = myTargets[GUID];
+	
+		OvaleEnemies.taggedEnemies = max(0, OvaleEnemies.taggedEnemies - 1);
+		myTargets[GUID] = nil;
+
+		if unitDied then
+			self:DebugTimestamp("Tagged enemy died (%d total, %d tagged): %s", self.activeEnemies, self.taggedEnemies, GUID);
+		else
+			self:DebugTimestamp("Tagged enemy removed( %d total, %d tagged): %s, last seen at %f", self.activeEnemies, self.taggedEnemies, GUID, taggedLastSeen);
+		end
+		
+		refreshNeeded = true;
+	end	
+
+	if refreshNeeded then
+		Ovale.refreshNeeded[playerGUID] = true;
+		self:SendMessage("Ovale_InactiveUnit", GUID, unitDied);
+	end
+	
+	self:StopProfiling("OvaleEnemies_RemoveEnemy");
 end
 
 function OvaleEnemies:DebugEnemies()
-	for guid, seen in pairs(self_enemyLastSeen) do
-		local name = self_enemyName[guid]
-		local tagged = self_taggedEnemyLastSeen[guid]
-		if tagged then
-			self:Print("Tagged enemy %s (%s) last seen at %f", guid, name, tagged)
+	for GUID, lastSeen in pairs(targets) do
+		local taggedTarget = myTargets[GUID];
+		
+		if taggedTarget then
+			self:Print("Tagged enemy %s last seen at %f", GUID, taggedTarget);
 		else
-			self:Print("Enemy %s (%s) last seen at %f", guid, name, seen)
+			self:Print("Enemy %s last seen at %f", GUID, lastSeen);
 		end
 	end
-	self:Print("Total enemies: %d", self.activeEnemies)
-	self:Print("Total tagged enemies: %d", self.taggedEnemies)
+
+	for GUID, lastSeen in pairs(minions) do
+		self:Print("Player minion %s last seen at %f", GUID, lastSeen);
+	end
+	
+	self:Print("Total enemies: %d", self.activeEnemies);
+	self:Print("Total tagged enemies: %d", self.taggedEnemies);
+	self:Print("Total player minions: %d", self.playerMinions);
 end
 --</public-static-methods>
+
 
 --[[----------------------------------------------------------------------------
 	State machine for simulator.
 --]]----------------------------------------------------------------------------
 
 --<public-static-properties>
-OvaleEnemies.statePrototype = {}
+OvaleEnemies.statePrototype = {};
 --</public-static-properties>
 
 --<private-static-properties>
-local statePrototype = OvaleEnemies.statePrototype
+local statePrototype = OvaleEnemies.statePrototype;
 --</private-static-properties>
 
 --<state-properties>
 -- Total number of active enemies.
-statePrototype.activeEnemies = nil
+statePrototype.activeEnemies = nil;
 -- Total number of tagged enemies.
-statePrototype.taggedEnemies = nil
+statePrototype.taggedEnemies = nil;
+-- Total number of player minions.
+statePrototype.playerMinions = nil;
+
 -- Requested number of enemies.
-statePrototype.enemies = nil
+statePrototype.enemies = nil;
 --</state-properties>
 
 --<public-static-methods>
 -- Initialize the state.
 function OvaleEnemies:InitializeState(state)
-	state.enemies = nil
+	state.enemies = nil;
 end
 
 -- Reset the state to the current conditions.
 function OvaleEnemies:ResetState(state)
-	self:StartProfiling("OvaleEnemies_ResetState")
-	state.activeEnemies = self.activeEnemies
-	state.taggedEnemies = self.taggedEnemies
-	self:StopProfiling("OvaleEnemies_ResetState")
+	self:StartProfiling("OvaleEnemies_ResetState");
+
+	state.activeEnemies = self.activeEnemies;
+	state.taggedEnemies = self.taggedEnemies;
+	state.playerMinions = self.playerMinions;
+
+	self:StopProfiling("OvaleEnemies_ResetState");
 end
 
 -- Release state resources prior to removing from the simulator.
 function OvaleEnemies:CleanState(state)
-	state.activeEnemies = nil
-	state.taggedEnemies = nil
-	state.enemies = nil
+	state.activeEnemies = nil;
+	state.taggedEnemies = nil;
+	state.playerMinions = nil;
+	state.enemies = nil;
 end
 --</public-static-methods>


### PR DESCRIPTION
Completely rewrote Enemies.lua, changed functionality to "Group Tagged" and "Personal Tagged", also removed enviromental damage which was counting, and added support for counting player summons.  This processes less events so is more efficient as the number of units sending events increases.
